### PR TITLE
maybe give some time for Android to response?

### DIFF
--- a/PN532_HSU/PN532_HSU.cpp
+++ b/PN532_HSU/PN532_HSU.cpp
@@ -85,6 +85,8 @@ int16_t PN532_HSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
 {
     uint8_t tmp[3];
     
+    delay(100);
+    
     DMSG("\nRead:  ");
     
     /** Frame Preamble and Start Code */
@@ -145,6 +147,8 @@ int8_t PN532_HSU::readAckFrame()
     const uint8_t PN532_ACK[] = {0, 0, 0xFF, 0, 0xFF, 0};
     uint8_t ackBuf[sizeof(PN532_ACK)];
     
+    delay(100);
+    
     DMSG("\nAck: ");
     
     if( receive(ackBuf, sizeof(PN532_ACK), PN532_ACK_WAIT_TIME) <= 0 ){
@@ -179,6 +183,7 @@ int8_t PN532_HSU::receive(uint8_t *buf, int len, uint16_t timeout)
       if (ret >= 0) {
         break;
      }
+     delay(10);
     } while((timeout == 0) || ((millis()- start_millis ) < timeout));
     
     if (ret < 0) {


### PR DESCRIPTION
I don't know why, but this modification makes P2P working on Nexus 5 Android 5.1 (non debug mode).
without this, I can't establish P2P when DEBUG preprocessor is commented out.