### PR TITLE
Bug fix: Cannot read SNEP data from Android, always got: "The received S...

### DIFF
--- a/PN532/snep.cpp
+++ b/PN532/snep.cpp
@@ -32,7 +32,11 @@ int8_t SNEP::write(const uint8_t *buf, uint8_t len, uint16_t timeout)
 
 	// check SNEP version
 	if (SNEP_DEFAULT_VERSION != rbuf[0]) {
-		DMSG("The received SNEP message's major version is different\n");
+		DMSG(F("The received SNEP message's major version is different, me: "));
+		DMSG(SNEP_DEFAULT_VERSION);
+		DMSG(", their: ");
+		DMSG(rbuf[0]);
+		DMSG("\n");
 		// To-do: send Unsupported Version response
 		return -4;
 	}
@@ -65,10 +69,22 @@ int16_t SNEP::read(uint8_t *buf, uint8_t len, uint16_t timeout)
 		return -3;
 	}
 
-
 	// check SNEP version
+	
+	// in case of platform specific bug, shift SNEP message for 4 bytes.
+	// tested on Nexus 5, Android 5.1
+	if (SNEP_DEFAULT_VERSION != buf[0] && SNEP_DEFAULT_VERSION == buf[4]) {
+		for (uint8_t i = 0; i < len - 4; i++) {
+			buf[i] = buf[i + 4];
+		}
+	}
+	
 	if (SNEP_DEFAULT_VERSION != buf[0]) {
-		DMSG("The received SNEP message's major version is different\n");
+		DMSG(F("SNEP->read: The received SNEP message's major version is different, me: "));
+		DMSG(SNEP_DEFAULT_VERSION);
+		DMSG(", their: ");
+		DMSG(buf[0]);
+		DMSG("\n");
 		// To-do: send Unsupported Version response
 		return -4;
 	}
@@ -84,8 +100,8 @@ int16_t SNEP::read(uint8_t *buf, uint8_t len, uint16_t timeout)
 	// length should not be more than 244 (header + body < 255, header = 6 + 3 + 2)
 	if (length > (status - 6)) {
 		DMSG("The SNEP message is too large: "); 
-        DMSG_INT(length);
-        DMSG_INT(status - 6);
+		DMSG_INT(length);
+		DMSG_INT(status - 6);
 		DMSG("\n");
 		return -4;
 	}


### PR DESCRIPTION
Cannot read SNEP data from Android, got "The received SNEP message's major version is different, me: 16, their: 0"

This error caused by wrong pointer when read response from Android.

Here is my Nexus 7 response:

```
00x00 0x13 0x20 0x00 0x10 0x02 0x00 0x00 0x00 0x3A 0xD1 0x01 0x36 0x55 0x02 0x67 ...
```

According to PN532 spec, the byte at offset 0 should be treated as TgGetData Status not the SNEP version.
The SNEP version appear at offset 4 (0x10) and SNEP Request Put method at offset 5 (0x02).

I don't know is this bug affected on Android specific platform, but my Android 5.1 Nexus 5 does.


Here is my full Arduino Serial log:

```
Write:  8E 81 84
Ack:  0 0 FF 0 FF 0
Read:   0 0 FF 3 FD D5 8F 0 9C 0
Write:  86
Ack:  0 0 FF 0 FF 0
Read:   0 0 FF 46 BA D5 87 0 13 20 0 10 2 0 0 0 3A D1 1 36 55 2 67 6F 6F 67 6C 65 2E 63 6F 2E 69 64 2F 3F 67 77 73 5F 72 64 3D 63 72 2C 73 73 6C 26 65 69 3D 49 67 55 79
Write:  8E 0 0
Ack:  0 0 FF 0 FF 0
Read:   0 0 FF 3 FD D5 8F 29 73 
Dump: 00x00 0x13 0x20 0x00 0x10 0x02 0x00 0x00 0x00 0x3A 0xD1 0x01 0x36 0x55 0x02 0x67 0x6F 0x6F 0x67 0x6C 0x65 0x2E 0x63 0x6F 0x2E 0x69 0x64 0x2F 0x3F 0x67 0x77 0x73 0x5F 0x72 0x64 0x3D 0x63 0x72 0x2C 0x73 0x73 0x6C 0x26 0x65 0x69 0x3D 0x49 0x67 0x55 0x79 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
The received SNEP message's major version is different, me: 16, their: 0
failed
```
