### PR TITLE
-Adding support for Nucleo SMT32F103RB

### DIFF
--- a/PN532/PN532_debug.h
+++ b/PN532/PN532_debug.h
@@ -1,20 +1,26 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
-//#define DEBUG
+#define DEBUG
 
 #include "Arduino.h"
 
-#ifdef DEBUG
-#define DMSG(args...)       Serial.print(args)
-#define DMSG_STR(str)       Serial.println(str)
-#define DMSG_HEX(num)       Serial.print(' '); Serial.print(num, HEX)
-#define DMSG_INT(num)       Serial.print(' '); Serial.print(num)
+#ifdef ARDUINO_STM_NUCLEU_F103RB
+    #define SERIALPORT Serial1
 #else
-#define DMSG(args...)
-#define DMSG_STR(str)
-#define DMSG_HEX(num)
-#define DMSG_INT(num)
+    #define SERIALPORT Serial
+#endif
+
+#ifdef DEBUG
+    #define DMSG(args...)       SERIALPORT.print(args)
+    #define DMSG_STR(str)       SERIALPORT.println(str)
+    #define DMSG_HEX(num)       SERIALPORT.print(' '); SERIALPORT.print(num, HEX)
+    #define DMSG_INT(num)       SERIALPORT.print(' '); SERIALPORT.print(num)
+#else
+    #define DMSG(args...)
+    #define DMSG_STR(str)
+    #define DMSG_HEX(num)
+    #define DMSG_INT(num)
 #endif
 
 #endif

--- a/PN532_I2C/PN532_I2C.cpp
+++ b/PN532_I2C/PN532_I2C.cpp
@@ -6,7 +6,7 @@
 #define PN532_I2C_ADDRESS       (0x48 >> 1)
 
 
-PN532_I2C::PN532_I2C(TwoWire &wire)
+PN532_I2C::PN532_I2C(WireBase &wire)
 {
     _wire = &wire;
     command = 0;
@@ -48,7 +48,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
             
             DMSG_HEX(header[i]);
         } else {
-            DMSG("\nToo many data to send, I2C doesn't support such a big packet\n");     // I2C max packet: 32 bytes
+            DMSG_STR("Header too long, I2C doesn't support such a big packet");     // I2C max packet: 32 bytes
             return PN532_INVALID_FRAME;
         }
     }
@@ -59,7 +59,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
             
             DMSG_HEX(body[i]);
         } else {
-            DMSG("\nToo many data to send, I2C doesn't support such a big packet\n");     // I2C max packet: 32 bytes
+            DMSG_STR("Body too long, I2C doesn't support such a big packet");     // I2C max packet: 32 bytes
             return PN532_INVALID_FRAME;
         }
     }
@@ -70,7 +70,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
     
     _wire->endTransmission();
     
-    DMSG('\n');
+    DMSG_STR();
 
     return readAckFrame();
 }
@@ -126,11 +126,11 @@ int16_t PN532_I2C::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
         
         DMSG_HEX(buf[i]);
     }
-    DMSG('\n');
+    DMSG_STR();
     
     uint8_t checksum = read();
     if (0 != (uint8_t)(sum + checksum)) {
-        DMSG("checksum is not ok\n");
+        DMSG_STR("checksum is not ok");
         return PN532_INVALID_FRAME;
     }
     read();         // POSTAMBLE
@@ -144,8 +144,7 @@ int8_t PN532_I2C::readAckFrame()
     uint8_t ackBuf[sizeof(PN532_ACK)];
     
     DMSG("wait for ack at : ");
-    DMSG(millis());
-    DMSG('\n');
+    DMSG_STR(millis());
     
     uint16_t time = 0;
     do {
@@ -158,14 +157,13 @@ int8_t PN532_I2C::readAckFrame()
         delay(1);
         time++;
         if (time > PN532_ACK_WAIT_TIME) {
-            DMSG("Time out when waiting for ACK\n");
+            DMSG_STR("Time out when waiting for ACK");
             return PN532_TIMEOUT;
         }
     } while (1); 
     
     DMSG("ready at : ");
-    DMSG(millis());
-    DMSG('\n');
+    DMSG_STR(millis());
     
 
     for (uint8_t i = 0; i < sizeof(PN532_ACK); i++) {
@@ -173,7 +171,7 @@ int8_t PN532_I2C::readAckFrame()
     }
     
     if (memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK))) {
-        DMSG("Invalid ACK\n");
+        DMSG_STR("Invalid ACK");
         return PN532_INVALID_ACK;
     }
     

--- a/PN532_I2C/PN532_I2C.h
+++ b/PN532_I2C/PN532_I2C.h
@@ -7,7 +7,7 @@
 
 class PN532_I2C : public PN532Interface {
 public:
-    PN532_I2C(TwoWire &wire);
+    PN532_I2C(WireBase &wire);
     
     void begin();
     void wakeup();
@@ -15,7 +15,7 @@ public:
     int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout);
     
 private:
-    TwoWire* _wire;
+    WireBase* _wire;
     uint8_t command;
     
     int8_t readAckFrame();


### PR DESCRIPTION
-PN532 TwoWire replaced by WireBase so that HardWire also can be used (tested with Nucleo STM32F103RB)
-Fixing line endings for debug messages

Signed-off-by: Christoph Tack <prog.send@gmail.com>