### PR TITLE
Low level SPI & I²C improvements

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -13,9 +13,8 @@
 
 #define HAL(func)   (_interface->func)
 
-PN532::PN532(PN532Interface &interface)
+PN532::PN532(PN532Interface &interface): _interface(&interface)
 {
-    _interface = &interface;
 }
 
 /**************************************************************************/
@@ -322,8 +321,8 @@ bool PN532::readPassiveTargetID(uint8_t cardbaudrate, uint8_t *uid, uint8_t *uid
     sens_res |= pn532_packetbuffer[3];
 
     DMSG("ATQA: 0x");  DMSG_HEX(sens_res);
-    DMSG("SAK: 0x");  DMSG_HEX(pn532_packetbuffer[4]);
-    DMSG("\n");
+    DMSG(" SAK: 0x");  DMSG_HEX(pn532_packetbuffer[4]);
+    DMSG_STR("");
 
     /* Card appears to be Mifare Classic */
     *uidLength = pn532_packetbuffer[5];
@@ -443,6 +442,7 @@ uint8_t PN532::mifareclassic_ReadDataBlock (uint8_t blockNumber, uint8_t *data)
 {
     DMSG("Trying to read 16 bytes from block ");
     DMSG_INT(blockNumber);
+    DMSG_STR();
 
     /* Prepare the command */
     pn532_packetbuffer[0] = PN532_COMMAND_INDATAEXCHANGE;
@@ -456,7 +456,9 @@ uint8_t PN532::mifareclassic_ReadDataBlock (uint8_t blockNumber, uint8_t *data)
     }
 
     /* Read the response packet */
-    HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer));
+    if(HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer))<0){
+        return 0;
+    }
 
     /* If byte 8 isn't 0x00 we probably have an error */
     if (pn532_packetbuffer[0] != 0x00) {

--- a/PN532/PN532_debug.h
+++ b/PN532/PN532_debug.h
@@ -1,15 +1,11 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
-#define DEBUG
+//#define DEBUG
 
 #include "Arduino.h"
 
-#ifdef ARDUINO_STM_NUCLEU_F103RB
-    #define SERIALPORT Serial1
-#else
-    #define SERIALPORT Serial
-#endif
+#define SERIALPORT Serial
 
 #ifdef DEBUG
     #define DMSG(args...)       SERIALPORT.print(args)

--- a/PN532/PN532_debug.h
+++ b/PN532/PN532_debug.h
@@ -1,20 +1,26 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
-//#define DEBUG
+#define DEBUG
 
 #include "Arduino.h"
 
-#ifdef DEBUG
-#define DMSG(args...)       Serial.print(args)
-#define DMSG_STR(str)       Serial.println(str)
-#define DMSG_HEX(num)       Serial.print(' '); Serial.print(num, HEX)
-#define DMSG_INT(num)       Serial.print(' '); Serial.print(num)
+#ifdef ARDUINO_STM_NUCLEU_F103RB
+    #define SERIALPORT Serial1
 #else
-#define DMSG(args...)
-#define DMSG_STR(str)
-#define DMSG_HEX(num)
-#define DMSG_INT(num)
+    #define SERIALPORT Serial
+#endif
+
+#ifdef DEBUG
+    #define DMSG(args...)       SERIALPORT.print(args)
+    #define DMSG_STR(str)       SERIALPORT.println(str)
+    #define DMSG_HEX(num)       SERIALPORT.print(' '); SERIALPORT.print(num, HEX)
+    #define DMSG_INT(num)       SERIALPORT.print(' '); SERIALPORT.print(num)
+#else
+    #define DMSG(args...)
+    #define DMSG_STR(str)
+    #define DMSG_HEX(num)
+    #define DMSG_INT(num)
 #endif
 
 #endif

--- a/PN532_I2C/PN532_I2C.cpp
+++ b/PN532_I2C/PN532_I2C.cpp
@@ -6,7 +6,7 @@
 #define PN532_I2C_ADDRESS       (0x48 >> 1)
 
 
-PN532_I2C::PN532_I2C(TwoWire &wire)
+PN532_I2C::PN532_I2C(WireBase &wire)
 {
     _wire = &wire;
     command = 0;
@@ -48,7 +48,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
             
             DMSG_HEX(header[i]);
         } else {
-            DMSG("\nToo many data to send, I2C doesn't support such a big packet\n");     // I2C max packet: 32 bytes
+            DMSG_STR("Header too long, I2C doesn't support such a big packet");     // I2C max packet: 32 bytes
             return PN532_INVALID_FRAME;
         }
     }
@@ -59,7 +59,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
             
             DMSG_HEX(body[i]);
         } else {
-            DMSG("\nToo many data to send, I2C doesn't support such a big packet\n");     // I2C max packet: 32 bytes
+            DMSG_STR("Body too long, I2C doesn't support such a big packet");     // I2C max packet: 32 bytes
             return PN532_INVALID_FRAME;
         }
     }
@@ -70,7 +70,7 @@ int8_t PN532_I2C::writeCommand(const uint8_t *header, uint8_t hlen, const uint8_
     
     _wire->endTransmission();
     
-    DMSG('\n');
+    DMSG_STR();
 
     return readAckFrame();
 }
@@ -126,11 +126,11 @@ int16_t PN532_I2C::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
         
         DMSG_HEX(buf[i]);
     }
-    DMSG('\n');
+    DMSG_STR();
     
     uint8_t checksum = read();
     if (0 != (uint8_t)(sum + checksum)) {
-        DMSG("checksum is not ok\n");
+        DMSG_STR("checksum is not ok");
         return PN532_INVALID_FRAME;
     }
     read();         // POSTAMBLE
@@ -144,8 +144,7 @@ int8_t PN532_I2C::readAckFrame()
     uint8_t ackBuf[sizeof(PN532_ACK)];
     
     DMSG("wait for ack at : ");
-    DMSG(millis());
-    DMSG('\n');
+    DMSG_STR(millis());
     
     uint16_t time = 0;
     do {
@@ -158,14 +157,13 @@ int8_t PN532_I2C::readAckFrame()
         delay(1);
         time++;
         if (time > PN532_ACK_WAIT_TIME) {
-            DMSG("Time out when waiting for ACK\n");
+            DMSG_STR("Time out when waiting for ACK");
             return PN532_TIMEOUT;
         }
     } while (1); 
     
     DMSG("ready at : ");
-    DMSG(millis());
-    DMSG('\n');
+    DMSG_STR(millis());
     
 
     for (uint8_t i = 0; i < sizeof(PN532_ACK); i++) {
@@ -173,7 +171,7 @@ int8_t PN532_I2C::readAckFrame()
     }
     
     if (memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK))) {
-        DMSG("Invalid ACK\n");
+        DMSG_STR("Invalid ACK");
         return PN532_INVALID_ACK;
     }
     

--- a/PN532_I2C/PN532_I2C.h
+++ b/PN532_I2C/PN532_I2C.h
@@ -7,7 +7,7 @@
 
 class PN532_I2C : public PN532Interface {
 public:
-    PN532_I2C(TwoWire &wire);
+    PN532_I2C(WireBase &wire);
     
     void begin();
     void wakeup();
@@ -15,7 +15,7 @@ public:
     int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout);
     
 private:
-    TwoWire* _wire;
+    WireBase* _wire;
     uint8_t command;
     
     int8_t readAckFrame();

--- a/PN532_I2C/PN532_I2C.h
+++ b/PN532_I2C/PN532_I2C.h
@@ -7,7 +7,7 @@
 
 class PN532_I2C : public PN532Interface {
 public:
-    PN532_I2C(WireBase &wire);
+    PN532_I2C(TwoWire &wire, uint8_t pinReset, uint8_t pinIrq);
     
     void begin();
     void wakeup();
@@ -15,10 +15,14 @@ public:
     int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout);
     
 private:
-    WireBase* _wire;
+    TwoWire* _wire;
     uint8_t command;
-    
+    uint8_t _reset;
+    uint8_t _irq;
+
     int8_t readAckFrame();
+    bool waitready(uint16_t timeout);
+
     
     inline uint8_t write(uint8_t data) {
         #if ARDUINO >= 100

--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -17,18 +17,8 @@ PN532_SPI::PN532_SPI(SPIClass &spi, uint8_t ss)
 void PN532_SPI::begin()
 {
     pinMode(_ss, OUTPUT);
+    _spiSettings=SPISettings(2000000, LSBFIRST, SPI_MODE0);
     _spi->begin();
-    _spi->setDataMode(SPI_MODE0);  // PN532 only supports mode0
-    _spi->setBitOrder(LSBFIRST);
-#ifdef __SAM3X8E__
-    /** DUE spi library does not support SPI_CLOCK_DIV8 macro */
-    _spi->setClockDivider(42);             // set clock 2MHz(max: 5MHz)
-#elif defined(ARDUINO_STM_NUCLEU_F103RB)
-    _spi->setClockDivider(SPI_CLOCK_DIV32); // set clock 72/32=2.25MHz (max: 5MHz)
-#else
-    _spi->setClockDivider(SPI_CLOCK_DIV8); // set clock 2MHz for 16MHz Arduino(max: 5MHz)
-#endif
-
 }
 
 void PN532_SPI::wakeup()

--- a/PN532_SPI/PN532_SPI.h
+++ b/PN532_SPI/PN532_SPI.h
@@ -17,6 +17,7 @@ public:
     
 private:
     SPIClass* _spi;
+    SPISettings _spiSettings;
     uint8_t   _ss;
     uint8_t command;
     
@@ -25,12 +26,18 @@ private:
     int8_t readAckFrame();
     
     inline void write(uint8_t data) {
+        _spi->beginTransaction(_spiSettings);
         _spi->transfer(data);
+        _spi->endTransaction();
     };
 
     inline uint8_t read() {
-        return _spi->transfer(0);
-    }; 
+        uint8_t retVal;
+        _spi->beginTransaction(_spiSettings);
+        retVal=_spi->transfer(0);
+        _spi->endTransaction();
+        return retVal;
+    };
 };
 
 #endif


### PR DESCRIPTION
- improving debug text layout
- avoid firmware crash when reading corrupt data (PN532.cpp, line 460)
- debug info can now also be sent to another serial port
- I²C interface now has two extra pins (also used by Adafruit PN532 library):
  - reset pin (because I managed to hang the PN532 and didn't get it running again without toggling this pin)
  - IRQ pin (which signals when data is ready, avoids I²C bus polling)
- SPI interface, using SPISettings with beginTransaction and endTransaction, so that this library is tolerant to changes of SPI mode settings if the host MCU wants to talk to other devices on the same SPI bus. (see also [Arduino SPISettings](https://www.arduino.cc/en/Tutorial/SPITransaction))
