### PR TITLE
Zee Livermorium patch - fix bug - if url length > 22, URI would be wrong

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -576,7 +576,7 @@ uint8_t PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber, uint8_t uriIden
         // 0xFE needs to be wrapped around to next block
         memcpy (sectorbuffer1 + 9, url, len);
         sectorbuffer2[0] = 0xFE;
-    } else if ((len > 7) || (len <= 22)) {
+    } else if ((len > 7) && (len <= 22)) {
         // Url fits in two blocks
         memcpy (sectorbuffer1 + 9, url, 7);
         memcpy (sectorbuffer2, url + 7, len - 7);
@@ -590,8 +590,8 @@ uint8_t PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber, uint8_t uriIden
         // Url fits in three blocks
         memcpy (sectorbuffer1 + 9, url, 7);
         memcpy (sectorbuffer2, url + 7, 16);
-        memcpy (sectorbuffer3, url + 23, len - 24);
-        sectorbuffer3[len - 22] = 0xFE;
+        memcpy (sectorbuffer3, url + 23, len - 23);
+        sectorbuffer3[len - 23] = 0xFE;
     }
 
     // Now write all three blocks back to the card


### PR DESCRIPTION
If you run "mifareclassic_formatndef" or "mifareclassic_updatendef" examples with an url longer than 22 character, before this commit your program would enter the if loop between line 638 and line 642, which cause NDEF reader not even able to recognize the formatted card. Also indexing in line 652 and 653 was not correct either. please refer to the last commit of ZeeLivermorium-patch branch too see the change.

I use memory dump example to debug this bug, you can verify it before you u merge pull request.

Blow are 2 screen shots, dark image is before the fix, white image is after the fix.
![screen shot 2018-04-20 at 11 48 46 pm](https://user-images.githubusercontent.com/14880636/39096542-06367c00-4617-11e8-97c6-b37ce54eea04.png)
![screen shot 2018-04-21 at 1 18 39 am](https://user-images.githubusercontent.com/14880636/39096543-0785eda2-4617-11e8-9f3e-321b2770604a.png)
