### PR TITLE
Fixed compiling problem for ESP32

### DIFF
--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -142,7 +142,7 @@ int16_t PN532_SPI::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
     return result;
 }
 
-boolean PN532_SPI::isReady()
+bool PN532_SPI::isReady()
 {
     digitalWrite(_ss, LOW);
 

--- a/PN532_SPI/PN532_SPI.h
+++ b/PN532_SPI/PN532_SPI.h
@@ -20,7 +20,7 @@ private:
     uint8_t   _ss;
     uint8_t command;
     
-    boolean isReady();
+    bool isReady();
     void writeFrame(const uint8_t *header, uint8_t hlen, const uint8_t *body = 0, uint8_t blen = 0);
     int8_t readAckFrame();
     


### PR DESCRIPTION
With this change the libraries compiled without errors in ESP32 platform as well.