### PR TITLE
while loop does not stop

### DIFF
--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -69,7 +69,7 @@ int16_t PN532_SPI::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
     while (!isReady()) {
         delay(1);
         time++;
-        if (timeout > 0 && time > timeout) {
+        if (time > timeout) {
             return PN532_TIMEOUT;
         }
     }


### PR DESCRIPTION

When timeout is passed with 0 to readResponse(), the while loop do not end forever.
On snep.h in NDEF library, default timeout value is 0 in function write on snep.h.
