### PR TITLE
Fix broken #include directives

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -7,8 +7,8 @@
 /**************************************************************************/
 
 #include "Arduino.h"
-#include "PN532/PN532/PN532.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532.h"
+#include "PN532_debug.h"
 #include <string.h>
 
 #define HAL(func)   (_interface->func)

--- a/PN532/emulatetag.cpp
+++ b/PN532/emulatetag.cpp
@@ -6,8 +6,8 @@
 */
 /**************************************************************************/
 
-#include "PN532/PN532/emulatetag.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "emulatetag.h"
+#include "PN532_debug.h"
 
 #include <string.h>
 

--- a/PN532/emulatetag.h
+++ b/PN532/emulatetag.h
@@ -11,7 +11,7 @@
 #ifndef __EMULATETAG_H__
 #define __EMULATETAG_H__
 
-#include "PN532/PN532/PN532.h"
+#include "PN532.h"
 
 #define NDEF_MAX_LENGTH 128 // altough ndef can handle up to 0xfffe in size, arduino cannot.
 typedef enum

--- a/PN532/examples/android_hce/android_hce.ino
+++ b/PN532/examples/android_hce/android_hce.ino
@@ -1,13 +1,13 @@
 #if 0
 #include <SPI.h>
-#include <PN532/PN532/PN532_SPI.h>
-#include "PN532/PN532/PN532.h"
+#include <PN532_SPI.h>
+#include "PN532.h"
 
   PN532_SPI pn532spi(SPI, 10);
   PN532 nfc(pn532spi);
 #elif 1
-#include <PN532/PN532/PN532_HSU.h>
-#include <PN532/PN532/PN532.h>
+#include <PN532_HSU.h>
+#include <PN532.h>
 
 PN532_HSU pn532hsu(Serial1);
 PN532 nfc(pn532hsu);

--- a/PN532/examples/emulate_tag_ndef/emulate_tag_ndef.ino
+++ b/PN532/examples/emulate_tag_ndef/emulate_tag_ndef.ino
@@ -1,16 +1,16 @@
-#include "PN532/PN532/emulatetag.h"
+#include "emulatetag.h"
 #include "NdefMessage.h"
 
 #if 0
 #include <SPI.h>
-#include <PN532/PN532/PN532_SPI.h>
-#include "PN532/PN532/PN532.h"
+#include <PN532_SPI.h>
+#include "PN532.h"
 
   PN532_SPI pn532spi(SPI, 10);
   EmulateTag nfc(pn532spi);
 #elif 1
-#include <PN532/PN532/PN532_HSU.h>
-#include <PN532/PN532/PN532.h>
+#include <PN532_HSU.h>
+#include <PN532.h>
 
 PN532_HSU pn532hsu(Serial1);
 EmulateTag nfc(pn532hsu);

--- a/PN532/examples/ntag21x_protect/ntag21x_protect.ino
+++ b/PN532/examples/ntag21x_protect/ntag21x_protect.ino
@@ -3,18 +3,18 @@
 // Valid address range for byte AUTH0 is from 00h to FFh.
 // If AUTH0 is set to a page address which is higher than the last page from the user configuration,
 // the password protection is effectively disabled
-#include <PN532/PN532/PN532.h>
+#include <PN532.h>
 #include <NfcAdapter.h>
 #if 0       // Using PN532's SPI (Seeed NFC shield)
 #include <SPI.h>
-#include <PN532/PN532_SPI/PN532_SPI.h>
+#include <PN532_SPI.h>
 
 
 PN532_SPI intf(SPI, 10);
 PN532 nfc = PN532(intf);
 #else        // Using PN532's I2C
 #include <Wire.h>
-#include <PN532/PN532_I2C/PN532_I2C.h>
+#include <PN532_I2C.h>
 
 PN532_I2C intf(Wire);
 PN532 nfc = PN532(intf);
@@ -22,8 +22,8 @@ PN532 nfc = PN532(intf);
 
 // Using PN532's UART (Grove NFC)
 
-// #include <PN532/PN532_I2C/PN532_I2C.h>
-// #include <PN532/PN532/PN532.h>
+// #include <PN532_I2C.h>
+// #include <PN532.h>
 // #include <NfcAdapter.h>
 // PN532_HSU intf(Serial1);
 // PN532 nfc = PN532(intf);

--- a/PN532/examples/ntag21x_rw/ntag21x_rw.ino
+++ b/PN532/examples/ntag21x_rw/ntag21x_rw.ino
@@ -2,19 +2,19 @@
 // Clean resets a tag back to factory-like state
 // For Mifare Classic, tag is zero'd and reformatted as Mifare Classic
 // For Mifare Ultralight, tags is zero'd and left empty
-#include <PN532/PN532/PN532.h>
+#include <PN532.h>
 #include <NfcAdapter.h>
 
 #if 0       // Using PN532's SPI (Seeed NFC shield)
 #include <SPI.h>
-#include <PN532/PN532_SPI/PN532_SPI.h>
+#include <PN532_SPI.h>
 
 
 PN532_SPI intf(SPI, 10);
 PN532 nfc = PN532(intf);
 #else        // Using PN532's I2C
 #include <Wire.h>
-#include <PN532/PN532_I2C/PN532_I2C.h>
+#include <PN532_I2C.h>
 
 
 PN532_I2C intf(Wire);
@@ -23,8 +23,8 @@ PN532 nfc = PN532(intf);
 
 // Using PN532's UART (Grove NFC)
 
-// #include <PN532/PN532_I2C/PN532_I2C.h>
-// #include <PN532/PN532/PN532.h>
+// #include <PN532_I2C.h>
+// #include <PN532.h>
 // #include <NfcAdapter.h>
 // PN532_HSU intf(Serial1);
 // PN532 nfc = PN532(intf);

--- a/PN532/examples/p2p_raw/p2p_raw.ino
+++ b/PN532/examples/p2p_raw/p2p_raw.ino
@@ -2,9 +2,9 @@
 // send a SNEP message to adnroid and get a message from android
 
 #include "SPI.h"
-#include "PN532/PN532_SPI/PN532_SPI.h"
-#include "PN532/PN532/llcp.h"
-#include "PN532/PN532/snep.h"
+#include "PN532_SPI.h"
+#include "llcp.h"
+#include "snep.h"
 
 PN532_SPI pn532spi(SPI, 10);
 SNEP nfc(pn532spi);

--- a/PN532/examples/p2p_with_ndef_library/p2p_with_ndef_library.ino
+++ b/PN532/examples/p2p_with_ndef_library/p2p_with_ndef_library.ino
@@ -3,8 +3,8 @@
 // note: [NDEF library](https://github.com/Don/NDEF) is needed.
 
 #include "SPI.h"
-#include "PN532/PN532_SPI/PN532_SPI.h"
-#include "PN532/PN532/snep.h"
+#include "PN532_SPI.h"
+#include "snep.h"
 #include "NdefMessage.h"
 
 PN532_SPI pn532spi(SPI, 10);

--- a/PN532/llcp.cpp
+++ b/PN532/llcp.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532/llcp.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "llcp.h"
+#include "PN532_debug.h"
 
 // LLCP PDU Type Values
 #define PDU_SYMM 0x00

--- a/PN532/llcp.h
+++ b/PN532/llcp.h
@@ -2,7 +2,7 @@
 #ifndef __LLCP_H__
 #define __LLCP_H__
 
-#include "PN532/PN532/mac_link.h"
+#include "mac_link.h"
 
 #define LLCP_DEFAULT_TIMEOUT  20000
 #define LLCP_DEFAULT_DSAP     0x04

--- a/PN532/mac_link.cpp
+++ b/PN532/mac_link.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532/mac_link.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "mac_link.h"
+#include "PN532_debug.h"
 
 int8_t MACLink::activateAsTarget(uint16_t timeout)
 {

--- a/PN532/mac_link.h
+++ b/PN532/mac_link.h
@@ -3,7 +3,7 @@
 #ifndef __MAC_LINK_H__
 #define __MAC_LINK_H__
 
-#include "PN532/PN532/PN532.h"
+#include "PN532.h"
 
 class MACLink {
 public:

--- a/PN532/snep.cpp
+++ b/PN532/snep.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532/snep.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "snep.h"
+#include "PN532_debug.h"
 
 int8_t SNEP::write(const uint8_t *buf, uint8_t len, uint16_t timeout)
 {

--- a/PN532/snep.h
+++ b/PN532/snep.h
@@ -3,7 +3,7 @@
 #ifndef __SNEP_H__
 #define __SNEP_H__
 
-#include "PN532/PN532/llcp.h"
+#include "llcp.h"
 
 #define SNEP_DEFAULT_VERSION	0x10	// Major: 1, Minor: 0
 

--- a/PN532_HSU/PN532_HSU.cpp
+++ b/PN532_HSU/PN532_HSU.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_HSU/PN532_HSU.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_HSU.h"
+#include "PN532_debug.h"
 
 PN532_HSU::PN532_HSU(HardwareSerial &serial)
 {

--- a/PN532_HSU/PN532_HSU.h
+++ b/PN532_HSU/PN532_HSU.h
@@ -2,7 +2,7 @@
 #ifndef __PN532_HSU_H__
 #define __PN532_HSU_H__
 
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 #include "Arduino.h"
 
 #define PN532_HSU_DEBUG

--- a/PN532_I2C/PN532_I2C.cpp
+++ b/PN532_I2C/PN532_I2C.cpp
@@ -2,8 +2,8 @@
  * @modified picospuch
  */
 
-#include "PN532/PN532_I2C/PN532_I2C.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_I2C.h"
+#include "PN532_debug.h"
 #include "Arduino.h"
 
 #define PN532_I2C_ADDRESS (0x48 >> 1)

--- a/PN532_I2C/PN532_I2C.h
+++ b/PN532_I2C/PN532_I2C.h
@@ -6,7 +6,7 @@
 #define __PN532_I2C_H__
 
 #include <Wire.h>
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 
 class PN532_I2C : public PN532Interface
 {

--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_SPI/PN532_SPI.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_SPI.h"
+#include "PN532_debug.h"
 #include "Arduino.h"
 
 #define STATUS_READ 2

--- a/PN532_SPI/PN532_SPI.h
+++ b/PN532_SPI/PN532_SPI.h
@@ -3,7 +3,7 @@
 #define __PN532_SPI_H__
 
 #include <SPI.h>
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 
 class PN532_SPI : public PN532Interface
 {

--- a/PN532_SWHSU/PN532_SWHSU.cpp
+++ b/PN532_SWHSU/PN532_SWHSU.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_SWHSU/PN532_SWHSU.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_SWHSU.h"
+#include "PN532_debug.h"
 
 
 PN532_SWHSU::PN532_SWHSU(SoftwareSerial &serial)

--- a/PN532_SWHSU/PN532_SWHSU.h
+++ b/PN532_SWHSU/PN532_SWHSU.h
@@ -4,7 +4,7 @@
 
 #include <SoftwareSerial.h>
 
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 #include "Arduino.h"
 
 #define PN532_SWHSU_DEBUG


### PR DESCRIPTION
These #include directives were broken in recent commits:
- https://github.com/Seeed-Studio/PN532/commit/1d6888aeb32160ad071a529089ea7bcd07619b5c
- https://github.com/Seeed-Studio/PN532/commit/f9c62da0811d154f55e2169db4761a093c603726
- https://github.com/Seeed-Studio/PN532/commit/f353f335f4a63b2271cf63d6767998668f36c11d

Resulting in many "No such file or directory" when attempting to use the library.

Apparently, those changes were necessary for whatever build system @baorepo is using, but they won't work with the Arduino IDE 99.99% of your users are using. My recommendation is that @baorepo find a way to make the existing `#include` directives work with their system, rather than breaking things for everyone else, and also that they take the time to test their changes using the Arduino IDE.