### PR TITLE
Support Passive Mode

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -387,6 +387,24 @@ bool PN532::setRFField(uint8_t autoRFCA, uint8_t rFOnOff)
 
 /**************************************************************************/
 /*!
+    Puts PN532 into passive detection state with IRQ while waiting for an ISO14443A target
+
+    @param  cardBaudRate  Baud rate of the card
+
+    @returns 1 if everything executed properly, 0 for an error
+*/
+bool PN532::startPassiveTargetIDDetection(uint8_t cardbaudrate) {
+    pn532_packetbuffer[0] = PN532_COMMAND_INLISTPASSIVETARGET;
+    pn532_packetbuffer[1] = 1; // max 1 cards at once (we can set this to 2 later)
+    pn532_packetbuffer[2] = cardbaudrate;
+
+    if (HAL(writeCommand)(pn532_packetbuffer, 3)) {
+        return 0x0;  // command failed
+    }
+}
+
+/**************************************************************************/
+/*!
     Waits for an ISO14443A target to enter the field
 
     @param  cardBaudRate  Baud rate of the card

--- a/PN532/PN532.h
+++ b/PN532/PN532.h
@@ -159,6 +159,7 @@ public:
 
     // ISO14443A functions
     bool inListPassiveTarget();
+    bool startPassiveTargetIDDetection(uint8_t cardbaudrate);
     bool readPassiveTargetID(uint8_t cardbaudrate, uint8_t *uid, uint8_t *uidLength, uint16_t timeout = 1000, bool inlist = false);
     bool inDataExchange(uint8_t *send, uint8_t sendLength, uint8_t *response, uint8_t *responseLength);
 


### PR DESCRIPTION
In many projects it's desirable to support non-blocking code - instead of constantly checking to see if a card is present, put the PN532 into interrupt mode where it will tell the MCU when a card is detected. This allows the MCU to free up cycles and only read the card reader when a card has been detected.

Usage is simple, once the device is configured, simply call `startPassiveTargetIDDetection(PN532_MIFARE_ISO14443A)` and monitor the IRQ pin after setting it to input. It's also possible to use `attachInterrupt()` (check for a FALLING pin)

When a card is detected, the IRQ pin is pulled low by the PN532. At this point, read the card as usual. Once the read is complete, remember to call `startPassiveTargetIDDetection()` again.