### PR TITLE
Added files for arduino-cli and simpler arduino compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 */
 !PN532*
 !NDEF*
+!src
 
 .DS_Store

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -401,6 +401,7 @@ bool PN532::startPassiveTargetIDDetection(uint8_t cardbaudrate) {
     if (HAL(writeCommand)(pn532_packetbuffer, 3)) {
         return 0x0;  // command failed
     }
+    return true;
 }
 
 /**************************************************************************/

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -307,7 +307,7 @@ bool PN532::SAMConfig(void)
     if (HAL(writeCommand)(pn532_packetbuffer, 4))
         return false;
 
-    return (0 < HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer)));
+    return (0 <= HAL(readResponse)(pn532_packetbuffer, sizeof(pn532_packetbuffer)));
 }
 
 /**************************************************************************/

--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -6,10 +6,10 @@
 */
 /**************************************************************************/
 
-#include "Arduino.h"
+#include <Arduino.h>
 #include "PN532.h"
 #include "PN532_debug.h"
-#include <string.h>
+#include <cstring>
 
 #define HAL(func)   (_interface->func)
 
@@ -312,12 +312,12 @@ bool PN532::SAMConfig(void)
 
 /**************************************************************************/
 /*!
-    @brief  Turn the module into power mode  will wake up on I2C or SPI request 
+    @brief  Turn the module into power mode  will wake up on I2C or SPI request
 */
 /**************************************************************************/
 bool PN532::powerDownMode()
 {
-    pn532_packetbuffer[0] = PN532_COMMAND_POWERDOWN; 
+    pn532_packetbuffer[0] = PN532_COMMAND_POWERDOWN;
     pn532_packetbuffer[1] = 0xC0; // I2C or SPI Wakeup
     pn532_packetbuffer[2] = 0x00; // no IRQ
 
@@ -357,13 +357,13 @@ bool PN532::setPassiveActivationRetries(uint8_t maxRetries)
 /*!
     Sets the RFon/off uint8_t of the RFConfiguration register
 
-    @param  autoRFCA    0x00 No check of the external field before 
-                        activation 
-                        
-                        0x02 Check the external field before 
+    @param  autoRFCA    0x00 No check of the external field before
                         activation
 
-    @param  rFOnOff     0x00 Switch the RF field off, 0x01 switch the RF 
+                        0x02 Check the external field before
+                        activation
+
+    @param  rFOnOff     0x00 Switch the RF field off, 0x01 switch the RF
                         field on
 
     @returns    1 if everything executed properly, 0 for an error
@@ -374,7 +374,7 @@ bool PN532::setRFField(uint8_t autoRFCA, uint8_t rFOnOff)
 {
     pn532_packetbuffer[0] = PN532_COMMAND_RFCONFIGURATION;
     pn532_packetbuffer[1] = 1;
-    pn532_packetbuffer[2] = 0x00 | autoRFCA | rFOnOff;  
+    pn532_packetbuffer[2] = 0x00 | autoRFCA | rFOnOff;
 
     if (HAL(writeCommand)(pn532_packetbuffer, 3)) {
         return 0x0;  // command failed
@@ -950,7 +950,7 @@ bool PN532::inListPassiveTarget()
 }
 
 int8_t PN532::tgInitAsTarget(const uint8_t* command, const uint8_t len, const uint16_t timeout){
-  
+
   int8_t status = HAL(writeCommand)(command, len);
     if (status < 0) {
         return -1;

--- a/PN532/PN532_debug.h
+++ b/PN532/PN532_debug.h
@@ -3,7 +3,7 @@
 
 //#define DEBUG
 
-#include "Arduino.h"
+#include <Arduino.h>
 
 #ifdef ARDUINO_SAMD_VARIANT_COMPLIANCE
     #define SERIAL SerialUSB

--- a/PN532/emulatetag.cpp
+++ b/PN532/emulatetag.cpp
@@ -9,7 +9,7 @@
 #include "emulatetag.h"
 #include "PN532_debug.h"
 
-#include <string.h>
+#include <cstring>
 
 #define MAX_TGREAD
 

--- a/PN532_HSU/PN532_HSU.cpp
+++ b/PN532_HSU/PN532_HSU.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_HSU/PN532_HSU.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_HSU.h"
+#include "../PN532/PN532_debug.h"
 
 PN532_HSU::PN532_HSU(HardwareSerial &serial)
 {

--- a/PN532_HSU/PN532_HSU.h
+++ b/PN532_HSU/PN532_HSU.h
@@ -2,8 +2,8 @@
 #ifndef __PN532_HSU_H__
 #define __PN532_HSU_H__
 
-#include "PN532/PN532/PN532Interface.h"
-#include "Arduino.h"
+#include "../PN532/PN532Interface.h"
+#include <Arduino.h>
 
 #define PN532_HSU_DEBUG
 

--- a/PN532_I2C/PN532_I2C.cpp
+++ b/PN532_I2C/PN532_I2C.cpp
@@ -3,8 +3,8 @@
  */
 
 #include "PN532_I2C.h"
-#include "PN532_debug.h"
-#include "Arduino.h"
+#include "../PN532/PN532_debug.h"
+#include <Arduino.h>
 
 #define PN532_I2C_ADDRESS (0x48 >> 1)
 

--- a/PN532_I2C/PN532_I2C.h
+++ b/PN532_I2C/PN532_I2C.h
@@ -6,7 +6,7 @@
 #define __PN532_I2C_H__
 
 #include <Wire.h>
-#include "PN532Interface.h"
+#include "../PN532/PN532Interface.h"
 
 class PN532_I2C : public PN532Interface
 {

--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -1,7 +1,7 @@
 
-#include "PN532/PN532_SPI/PN532_SPI.h"
-#include "PN532/PN532/PN532_debug.h"
-#include "Arduino.h"
+#include "PN532_SPI.h"
+#include "../PN532/PN532_debug.h"
+#include <Arduino.h>
 
 #define STATUS_READ 2
 #define DATA_WRITE 1

--- a/PN532_SPI/PN532_SPI.h
+++ b/PN532_SPI/PN532_SPI.h
@@ -3,7 +3,7 @@
 #define __PN532_SPI_H__
 
 #include <SPI.h>
-#include "PN532/PN532/PN532Interface.h"
+#include "../PN532/PN532Interface.h"
 
 class PN532_SPI : public PN532Interface
 {

--- a/PN532_SWHSU/PN532_SWHSU.cpp
+++ b/PN532_SWHSU/PN532_SWHSU.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_SWHSU/PN532_SWHSU.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_SWHSU.h"
+#include "../PN532/PN532_debug.h"
 
 
 PN532_SWHSU::PN532_SWHSU(SoftwareSerial &serial)
@@ -46,20 +46,20 @@ int8_t PN532_SWHSU::writeCommand(const uint8_t *header, uint8_t hlen, const uint
     }
 
     command = header[0];
-    
+
     _serial->write((uint8_t) PN532_PREAMBLE);
     _serial->write((uint8_t) PN532_STARTCODE1);
     _serial->write((uint8_t) PN532_STARTCODE2);
-    
+
     uint8_t length = hlen + blen + 1;   // length of data field: TFI + DATA
     _serial->write(length);
     _serial->write(~length + 1);         // checksum of length
-    
+
     _serial->write((uint8_t) PN532_HOSTTOPN532);
     uint8_t sum = PN532_HOSTTOPN532;    // sum of TFI + DATA
 
     DMSG("\nWrite: ");
-    
+
     _serial->write(header, hlen);
     for (uint8_t i = 0; i < hlen; i++) {
         sum += header[i];
@@ -73,7 +73,7 @@ int8_t PN532_SWHSU::writeCommand(const uint8_t *header, uint8_t hlen, const uint
 
         DMSG_HEX(body[i]);
     }
-    
+
     uint8_t checksum = ~sum + 1;            // checksum of TFI + DATA
     _serial->write(checksum);
     _serial->write((uint8_t) PN532_POSTAMBLE);
@@ -84,9 +84,9 @@ int8_t PN532_SWHSU::writeCommand(const uint8_t *header, uint8_t hlen, const uint
 int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
 {
     uint8_t tmp[3];
-    
+
     DMSG("\nRead:  ");
-    
+
     /** Frame Preamble and Start Code */
     if(receive(tmp, 3, timeout)<=0){
         return PN532_TIMEOUT;
@@ -95,7 +95,7 @@ int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
         DMSG("Preamble error");
         return PN532_INVALID_FRAME;
     }
-    
+
     /** receive length and check */
     uint8_t length[2];
     if(receive(length, 2, timeout) <= 0){
@@ -109,7 +109,7 @@ int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
     if( length[0] > len){
         return PN532_NO_SPACE;
     }
-    
+
     /** receive command byte */
     uint8_t cmd = command + 1;               // response command
     if(receive(tmp, 2, timeout) <= 0){
@@ -119,7 +119,7 @@ int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
         DMSG("Command error");
         return PN532_INVALID_FRAME;
     }
-    
+
     if(receive(buf, length[0], timeout) != length[0]){
         return PN532_TIMEOUT;
     }
@@ -127,7 +127,7 @@ int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
     for(uint8_t i=0; i<length[0]; i++){
         sum += buf[i];
     }
-    
+
     /** checksum and postamble */
     if(receive(tmp, 2, timeout) <= 0){
         return PN532_TIMEOUT;
@@ -136,7 +136,7 @@ int16_t PN532_SWHSU::readResponse(uint8_t buf[], uint8_t len, uint16_t timeout)
         DMSG("Checksum error");
         return PN532_INVALID_FRAME;
     }
-    
+
     return length[0];
 }
 
@@ -144,14 +144,14 @@ int8_t PN532_SWHSU::readAckFrame()
 {
     const uint8_t PN532_ACK[] = {0, 0, 0xFF, 0, 0xFF, 0};
     uint8_t ackBuf[sizeof(PN532_ACK)];
-    
+
     DMSG("\nAck: ");
-    
+
     if( receive(ackBuf, sizeof(PN532_ACK), PN532_ACK_WAIT_TIME) <= 0 ){
         DMSG("Timeout\n");
         return PN532_TIMEOUT;
     }
-    
+
     if( memcmp(ackBuf, PN532_ACK, sizeof(PN532_ACK)) ){
         DMSG("Invalid\n");
         return PN532_INVALID_ACK;
@@ -171,7 +171,7 @@ int8_t PN532_SWHSU::receive(uint8_t *buf, int len, uint16_t timeout)
   int read_bytes = 0;
   int ret;
   unsigned long start_millis;
-  
+
   while (read_bytes < len) {
     start_millis = millis();
     do {
@@ -180,7 +180,7 @@ int8_t PN532_SWHSU::receive(uint8_t *buf, int len, uint16_t timeout)
         break;
      }
     } while((timeout == 0) || ((millis()- start_millis ) < timeout));
-    
+
     if (ret < 0) {
         if(read_bytes){
             return read_bytes;

--- a/PN532_SWHSU/PN532_SWHSU.h
+++ b/PN532_SWHSU/PN532_SWHSU.h
@@ -4,8 +4,8 @@
 
 #include <SoftwareSerial.h>
 
-#include "PN532/PN532/PN532Interface.h"
-#include "Arduino.h"
+#include "../PN532/PN532Interface.h"
+#include <Arduino.h>
 
 #define PN532_SWHSU_DEBUG
 
@@ -14,18 +14,18 @@
 class PN532_SWHSU : public PN532Interface {
 public:
     PN532_SWHSU(SoftwareSerial &serial);
-    
+
     void begin();
     void wakeup();
     virtual int8_t writeCommand(const uint8_t *header, uint8_t hlen, const uint8_t *body = 0, uint8_t blen = 0);
     int16_t readResponse(uint8_t buf[], uint8_t len, uint16_t timeout);
-    
+
 private:
     SoftwareSerial* _serial;
     uint8_t command;
-    
+
     int8_t readAckFrame();
-    
+
     int8_t receive(uint8_t *buf, int len, uint16_t timeout=PN532_SWHSU_READ_TIMEOUT);
 };
 

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,11 @@
+name=PN532
+version=1.0.0
+author=Seed Studio & Others
+maintainer=Seed Studio & contributors
+sentence=PN532 library
+paragraph=PN532 library
+category=Generic
+url=https://github.com/Seeed-Studio/PN532
+architectures=*
+includes=PN532.h
+depends=NDEF

--- a/src/PN532_LIB.h
+++ b/src/PN532_LIB.h
@@ -1,0 +1,41 @@
+#ifndef PN532_LIB_FULL_H
+#define PN532_LIB_FULL_H
+
+#include "../PN532/PN532.h"
+#if (defined PN532_USE_HSU) && PN532_USE_HSU
+#include "../PN532_HSU/PN532_HSU.h"
+#elif (defined PN532_USE_I2C) && PN532_USE_I2C
+#include "../PN532_I2C/PN532_I2C.h"
+#elif (defined PN532_USE_SPI) && PN532_USE_SPI
+#include "../PN532_SPI/PN532_SPI.h"
+#elif (defined PN532_USE_SWHSU) && PN532_USE_SWHSU
+#include "../PN532_SWHSU/PN532_SWHSU.h"
+#else
+#error "Please, before includeing this header, define to 1 one of: PN532_USE_HSU, PN532_USE_I2C, PN532_USE_SPI, PN532_USE_SWHSU, and in a single .cpp/.ino also define to 1 PN532_INCLUDE_IMPLEMENTATION"
+#endif
+
+
+// This macro must be defined just in a single cpp/.ino:
+// #define PN532_INCLUDE_IMPLEMENTATION 1
+#if (defined PN532_INCLUDE_IMPLEMENTATION) && PN532_INCLUDE_IMPLEMENTATION
+#include "../PN532/emulatetag.cpp"
+#include "../PN532/llcp.cpp"
+#include "../PN532/mac_link.cpp"
+#include "../PN532/PN532.cpp"
+#include "../PN532/snep.cpp"
+
+#if (defined PN532_USE_HSU) && PN532_USE_HSU
+#include "../PN532_HSU/PN532_HSU.cpp"
+#elif (defined PN532_USE_I2C) && PN532_USE_I2C
+#include "../PN532_I2C/PN532_I2C.cpp"
+#elif (defined PN532_USE_SPI) && PN532_USE_SPI
+#include "PN532_SPI/PN532_SPI.cpp"
+#elif (defined PN532_USE_SWHSU) && PN532_USE_SWHSU
+#include "PN532_SWHSU/PN532_SWHSU.cpp"
+#else
+#error "Please, before includeing this header, define to 1 one of: PN532_USE_HSU, PN532_USE_I2C, PN532_USE_SPI, PN532_USE_SWHSU"
+#endif
+
+#endif
+
+#endif


### PR DESCRIPTION
Hi,

this pr proposes the following improvements:
1. Now it is possible to install via Arduino/Arduino-cli thanks to the inclusion of `library.properties` file
2. Also, to allow this kind of installation, I added the `src/PN532_LIB.h`
3. I also fixed some wrong includes in the other files
4. Added a missing return statement
5. Fixed a wrong return statement (wrong: `<`, correct: `<=`)

It is possible to use everything as before, but if the library is installied via Arduino/Arduino-cli , the new usage is the following:

1. Include `PN532_LIB.h` wherever you need, choosing also the communication protocol, for example:
```c++
// Here we choose the I2C protocol:
//#define PN532_USE_HSU 1
#define PN532_USE_I2C 1
//#define PN532_USE_SPI 1
//#define PN532_USE_SWHSU 1
#include <PN532_LIB.h>
```
2. In just one `.ino/.cpp` file, include the implementation:
```c++
// We must always choose the same protocol, so let's continue with I2C in this example:
//#define PN532_USE_HSU 1
#define PN532_USE_I2C 1
//#define PN532_USE_SPI 1
//#define PN532_USE_SWHSU 1
// And here we include the implementation:
#define PN532_INCLUDE_IMPLEMENTATION 1
#include <PN532_LIB.h>
```

Regards