### PR TITLE
Fix `No such file or directory` error

### DIFF
--- a/PN532_HSU/PN532_HSU.cpp
+++ b/PN532_HSU/PN532_HSU.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_HSU/PN532_HSU.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_HSU.h"
+#include "PN532_debug.h"
 
 PN532_HSU::PN532_HSU(HardwareSerial &serial)
 {

--- a/PN532_HSU/PN532_HSU.h
+++ b/PN532_HSU/PN532_HSU.h
@@ -2,7 +2,7 @@
 #ifndef __PN532_HSU_H__
 #define __PN532_HSU_H__
 
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 #include "Arduino.h"
 
 #define PN532_HSU_DEBUG

--- a/PN532_SPI/PN532_SPI.cpp
+++ b/PN532_SPI/PN532_SPI.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_SPI/PN532_SPI.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_SPI.h"
+#include "PN532_debug.h"
 #include "Arduino.h"
 
 #define STATUS_READ 2

--- a/PN532_SPI/PN532_SPI.h
+++ b/PN532_SPI/PN532_SPI.h
@@ -3,7 +3,7 @@
 #define __PN532_SPI_H__
 
 #include <SPI.h>
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 
 class PN532_SPI : public PN532Interface
 {

--- a/PN532_SWHSU/PN532_SWHSU.cpp
+++ b/PN532_SWHSU/PN532_SWHSU.cpp
@@ -1,6 +1,6 @@
 
-#include "PN532/PN532_SWHSU/PN532_SWHSU.h"
-#include "PN532/PN532/PN532_debug.h"
+#include "PN532_SWHSU.h"
+#include "PN532_debug.h"
 
 
 PN532_SWHSU::PN532_SWHSU(SoftwareSerial &serial)

--- a/PN532_SWHSU/PN532_SWHSU.h
+++ b/PN532_SWHSU/PN532_SWHSU.h
@@ -4,7 +4,7 @@
 
 #include <SoftwareSerial.h>
 
-#include "PN532/PN532/PN532Interface.h"
+#include "PN532Interface.h"
 #include "Arduino.h"
 
 #define PN532_SWHSU_DEBUG


### PR DESCRIPTION
Fix Arduino compilation error when using `HSU`/`SWHSU`/`SPI` interface
Fix is the same, as for the `I2C` interface: https://github.com/Seeed-Studio/PN532/pull/97