### PR TITLE
fix PrintHEX output on AVR MCU

### DIFF
--- a/PN532/PN532.cpp
+++ b/PN532/PN532.cpp
@@ -41,12 +41,13 @@ void PN532::PrintHex(const uint8_t *data, const uint32_t numBytes)
 {
 #ifdef ARDUINO
     for (uint8_t i = 0; i < numBytes; i++) {
-        if (data[i] < 0x10) {
+        uint8_t c = data[i];
+        if ( c < 0x10) {
             SERIAL.print(" 0");
         } else {
             SERIAL.print(' ');
         }
-        SERIAL.print(data[i], HEX);
+        SERIAL.print(c, HEX);
     }
     SERIAL.println("");
 #else
@@ -72,16 +73,17 @@ void PN532::PrintHexChar(const uint8_t *data, const uint32_t numBytes)
 {
 #ifdef ARDUINO
     for (uint8_t i = 0; i < numBytes; i++) {
-        if (data[i] < 0x10) {
+        uint8_t c = data[i];
+        if ( c < 0x10) {
             SERIAL.print(" 0");
         } else {
             SERIAL.print(' ');
         }
-        SERIAL.print(data[i], HEX);
+        SERIAL.print(c, HEX);
     }
     SERIAL.print("    ");
     for (uint8_t i = 0; i < numBytes; i++) {
-        char c = data[i];
+        uint8_t c = data[i];
         if (c <= 0x1f || c > 0x7f) {
             SERIAL.print('.');
         } else {
@@ -708,7 +710,7 @@ uint8_t PN532::mifareclassic_WriteNDEFURI (uint8_t sectorNumber, uint8_t uriIden
     // in NDEF records
 
     // Setup the sector buffer (w/pre-formatted TLV wrapper and NDEF message)
-    uint8_t sectorbuffer1[16] = {0x00, 0x00, 0x03, len + 5, 0xD1, 0x01, len + 1, 0x55, uriIdentifier, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    uint8_t sectorbuffer1[16] = {0x00, 0x00, 0x03, (uint8_t)(len + 5), 0xD1, 0x01, (uint8_t)(len + 1), 0x55, uriIdentifier, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t sectorbuffer2[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t sectorbuffer3[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t sectorbuffer4[16] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};


### PR DESCRIPTION
Some times bytes can be output as LONG.