### PR TITLE
Fix NDEF dependency name

### DIFF
--- a/library.json
+++ b/library.json
@@ -42,7 +42,7 @@
   },
   "dependencies": [
     {
-      "name": "external-repo",
+      "name": "NDEF",
       "version": "https://github.com/don/NDEF"
     }
   ],


### PR DESCRIPTION
The NDEF dependency name was incorrectly set to `external-repo` ([following the platform.io example](https://docs.platformio.org/en/latest/manifests/library-json/fields/dependencies.html)) which results in the NDEF library being cloned into a folder called `external-repo`.

It makes more sense to call it `NDEF`; not only to make its description clearer but also to prevent collisions.